### PR TITLE
chore(renovate): simplify grouping configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "group:allDigest",
-    "group:allNonMajor",
-    "group:linters"
+    "group:all"
   ]
 }


### PR DESCRIPTION
Simplified the Renovate configuration by replacing individual groups (allDigest, allNonMajor, linters) with a single group:all setting to streamline the update management process.
