### PR TITLE
chore(nx): update configuration for GitHub release creation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -75,7 +75,8 @@
           "commitReferences": true,
           "versionTitleDate": true,
           "mapAuthorsToGitHubUsernames": true
-        }
+        },
+        "createRelease": "github"
       },
       "projectChangelogs": {
         "renderOptions": {
@@ -83,8 +84,7 @@
           "commitReferences": true,
           "versionTitleDate": true,
           "mapAuthorsToGitHubUsernames": true
-        },
-        "createRelease": "github"
+        }
       }
     }
   }


### PR DESCRIPTION
# chore(nx): update configuration for GitHub release creation

## Description

This pull request updates the `nx.json` configuration to enable GitHub release creation for main project only. 
